### PR TITLE
session detail page in correct stack location

### DIFF
--- a/front-end/app/(tabs)/library/song/[id].tsx
+++ b/front-end/app/(tabs)/library/song/[id].tsx
@@ -4,12 +4,21 @@ import { useArtistsStore } from '@/stores/artist-store';
 import { useSessionItemsStore } from '@/stores/session-item-store';
 import { useSongsStore } from '@/stores/song-store';
 import { router, useLocalSearchParams } from 'expo-router';
+import { useEffect } from 'react';
 import { Pressable, Text, View } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 
 export default function SongDetailPage() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const songId = id;
+
+  const fetchSessionItemBySongId = useSessionItemsStore(
+    (state) => state.fetchSessionItemBySongId
+  );
+
+  useEffect(() => {
+    fetchSessionItemBySongId(songId);
+  }, [songId, fetchSessionItemBySongId]);
 
   // Stores
   const songs = useSongsStore((state) => state.songs);

--- a/front-end/app/(tabs)/sessions/_layout.tsx
+++ b/front-end/app/(tabs)/sessions/_layout.tsx
@@ -13,14 +13,6 @@ export default function SessionsStack() {
         }}
       />
       <Stack.Screen
-        name="[id]"
-        options={{
-          title: 'Session Details',
-          headerShown: true,
-          headerShadowVisible: false,
-        }}
-      />
-      <Stack.Screen
         name="make-session"
         options={{
           title: 'Create Session',

--- a/front-end/app/_layout.tsx
+++ b/front-end/app/_layout.tsx
@@ -68,21 +68,8 @@ export default function RootLayout() {
             {/* <StatusBar style={isDarkColorScheme ? 'light' : 'dark'} /> */}
             <Stack>
               <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-              <Stack.Screen
-                name="stat-detail"
-                options={{
-                  headerShown: false,
-                  presentation: 'modal', // Or 'card' for standard push animation
-                }}
-              />
-              {/* NEW: Stack for detailed session view */}
-              <Stack.Screen
-                name="session-detail"
-                options={{
-                  headerShown: false, // Manage headers within session-detail/_layout.tsx
-                  presentation: 'modal', // Or 'card'
-                }}
-              />
+              <Stack.Screen name="stat-detail" />
+              <Stack.Screen name="session-detail/[id]" />
               <Stack.Screen name="+not-found" />
             </Stack>
             <PortalHost />

--- a/front-end/app/session-detail/[id].tsx
+++ b/front-end/app/session-detail/[id].tsx
@@ -7,7 +7,7 @@ import { formatTimestampToDate, formatToMinutes } from '@/utils/date-time';
 import { groupItems } from '@/utils/filter';
 import { Stack, useLocalSearchParams } from 'expo-router';
 import React, { useEffect } from 'react';
-import { ScrollView, Text, View } from 'react-native';
+import { SafeAreaView, ScrollView, Text, View } from 'react-native';
 
 export default function PracticeSessionDetailPage() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -47,13 +47,13 @@ export default function PracticeSessionDetailPage() {
         }}
       />
       {/* Content */}
-      <View className="flex-1 px-4">
+      <SafeAreaView className="flex-1 p-4">
         <ScrollView contentContainerStyle={{ paddingBottom: 120 }}>
           <ExerciseDetailCard items={exercises} />
           <SongDetailCard items={songs} />
           <NotesDetailCard notes={session.notes} />
         </ScrollView>
-      </View>
+      </SafeAreaView>
     </>
   );
 }

--- a/front-end/components/sessions/PracticeSessionSummaryCard.tsx
+++ b/front-end/components/sessions/PracticeSessionSummaryCard.tsx
@@ -99,7 +99,7 @@ export function PracticeSessionSummaryCard({ session }: PracticeSessionSummaryCa
                 className="mt-4 bg-orange-500 "
                 onPress={(e) => {
                   e.stopPropagation?.(); // Only on web
-                  router.push(`/sessions/${session.id}`);
+                  router.push(`/session-detail/${session.id}`);
                 }}
               >
                 <Text className="text-white font-medium">View Full Session</Text>

--- a/front-end/components/shared/ItemDetailPage.tsx
+++ b/front-end/components/shared/ItemDetailPage.tsx
@@ -32,7 +32,7 @@ export default function ItemDetailPage({
   const [status, setStatus] = useState<'idle' | 'saving' | 'saved' | 'error' | 'bad'>('idle');
 
   const handleSessionPress = (sessionId: string) => {
-    router.navigate(`/sessions/${sessionId}`);
+    router.navigate(`/session-detail/${sessionId}`);
   };
 
   const handleUpdateGoal = async () => {
@@ -70,7 +70,7 @@ export default function ItemDetailPage({
       </View>
 
       {sessionItems.length > 0 ? (
-        <View>
+        <View className="mb-4">
           <Separator color="red" />
 
           {/* Graph */}
@@ -84,7 +84,7 @@ export default function ItemDetailPage({
           <Separator color="red" />
 
           {/* Session List */}
-          <Text className="text-2xl font-semibold my-4">Sessions</Text>
+          <Text className="text-2xl font-semibold y-4">Sessions</Text>
           {sessionItems.map((item) => {
             const session = sessionMap.get(item.session_id);
             if (!session) {
@@ -110,7 +110,8 @@ export default function ItemDetailPage({
           <Text className="text-2xl font-semibold my-4">Sessions</Text>
           <Text className="text-gray-500 italic">No sessions logged yet.</Text>
         </View>
-      )}
-    </View>
+      )
+      }
+    </View >
   );
 }


### PR DESCRIPTION
Previously, having the session detail page in the `(tabs)/` directory meant that leaving that tab would break the stack. That was annoying since we wanted to be able to see Session Details either from sessions or the library. Moving it outside maintains it on the app-wide header
