### PR TITLE
Refactor logic into utils

### DIFF
--- a/front-end/app/library-forms/edit-song/[songId].tsx
+++ b/front-end/app/library-forms/edit-song/[songId].tsx
@@ -5,7 +5,7 @@ import { useArtistsStore } from '@/stores/artist-store';
 import { useSongsStore } from '@/stores/song-store';
 import { LocalArtist } from '@/types/artist';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import Fuse from 'fuse.js';
+import { fuzzySearchArtists } from '@/utils/song-edit';
 import React, { useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, Alert, Pressable, Text, View } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
@@ -32,25 +32,9 @@ export default function EditSongPage() {
     fetchArtists();
   }, [fetchArtists]);
 
-  // Fuzzy search using Fuse.js
+  // Fuzzy search using utility function
   const getFilteredArtists = useCallback(() => {
-    if (!artistQuery) return [];
-
-    // Initialize Fuse instance with options
-    const fuse = new Fuse(artists, {
-      keys: ['name'],
-      threshold: 0.3, // Lower threshold = more strict matching
-      distance: 100, // How far to search for matches
-      minMatchCharLength: 1,
-      shouldSort: true, // Sort by score
-      includeScore: true
-    });
-
-    const results = fuse.search(artistQuery);
-    // Filter out low-quality matches (high scores mean less relevant)
-    return results
-      .filter(result => result.score && result.score < 0.6)
-      .map(result => result.item);
+    return fuzzySearchArtists(artists, artistQuery);
   }, [artistQuery, artists]);
 
   const handleSelectArtist = (artistName: string) => {

--- a/front-end/components/forms/SectionForm.tsx
+++ b/front-end/components/forms/SectionForm.tsx
@@ -1,6 +1,11 @@
 import { ThemedIcon } from '@/components/icons/ThemedIcon';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { ExerciseNamingType, SectionFormData } from '@/types/book';
+import {
+  updateCustomName,
+  updateExerciseCount,
+  updateNamingType,
+} from '@/utils/section-form';
 import { ChevronDown } from 'lucide-react-native';
 import { useState } from 'react';
 import { Pressable, Text, View } from 'react-native';
@@ -26,30 +31,19 @@ export function SectionForm({ section, onUpdate, onDelete, index }: SectionFormP
   });
 
   const handleExerciseCountChange = (value: string) => {
-    const count = parseInt(value) || 0;
-    onUpdate({
-      ...section,
-      exerciseCount: count,
-      customExerciseNames: Array(count).fill('').map((_, i) => customNames[i] || '')
-    });
+    const updated = updateExerciseCount(section, value, customNames);
+    onUpdate(updated);
   };
 
   const handleNamingTypeChange = (type: ExerciseNamingType) => {
-    onUpdate({
-      ...section,
-      exerciseNaming: type,
-      customExerciseNames: type === 'custom' ? Array(section.exerciseCount).fill('') : undefined
-    });
+    const updated = updateNamingType(section, type);
+    onUpdate(updated);
   };
 
   const handleCustomNameChange = (index: number, value: string) => {
-    const newNames = [...customNames];
-    newNames[index] = value;
-    setCustomNames(newNames);
-    onUpdate({
-      ...section,
-      customExerciseNames: newNames
-    });
+    const { names, section: updated } = updateCustomName(section, customNames, index, value);
+    setCustomNames(names);
+    onUpdate(updated);
   };
 
   return (

--- a/front-end/components/stats/ItemProgressGraph.tsx
+++ b/front-end/components/stats/ItemProgressGraph.tsx
@@ -1,8 +1,8 @@
 import { ActiveValueIndicator } from "@/components/stats/ActiveValueIndicator";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ItemProgressPoint, TimeRange } from "@/types/stats";
-import { calculateCutoffDate } from "@/utils/date-time";
 import { formatDateByRange } from "@/utils/stats";
+import { filterProgressData } from "@/utils/item-progress";
 import { useFont } from "@shopify/react-native-skia";
 import React, { useMemo, useState } from "react";
 import { Text, View } from "react-native";
@@ -32,21 +32,10 @@ export default function ItemProgressGraph({
   const [timeRange, setTimeRange] = useState<TimeRange>('month');
 
   const now = Date.now();
-  const cutoffDate =
-    timeRange === 'all' && data.length > 0
-      ? Math.min(...data.map(point => point.timestamp))
-      : calculateCutoffDate(timeRange).getTime();
-
-  const filteredData = useMemo(() => {
-    return data
-      .filter(point => point.timestamp >= cutoffDate)
-      .filter(point => point.timestamp <= now)
-      .sort((a, b) => a.timestamp - b.timestamp)
-      .map(point => ({
-        ...point,
-        timestamp: point.timestamp, // optional, if no transformation needed
-      }));
-  }, [data, cutoffDate, now]);
+  const { filtered: filteredData, cutoffDate } = useMemo(
+    () => filterProgressData(data, timeRange, now),
+    [data, timeRange, now]
+  );
 
 
   if (!font) {

--- a/front-end/utils/__tests__/books-tab.test.ts
+++ b/front-end/utils/__tests__/books-tab.test.ts
@@ -1,0 +1,54 @@
+import {
+  filterByName,
+  isExerciseInDraft,
+  createSessionExerciseItem,
+  createSetlistExerciseItem,
+  findSessionExerciseItemId,
+  findSetlistExerciseItemId,
+} from '@/utils/books-tab';
+import { DraftSession } from '@/types/session';
+import { DraftSetlist } from '@/types/setlist';
+import { BookWithCountsRow } from '@/types/book';
+import { SectionWithCountsRow } from '@/types/section';
+import { LocalExercise } from '@/types/exercise';
+
+describe('books-tab utils', () => {
+  test('filterByName filters items by query', () => {
+    const items = [{ name: 'Alpha' }, { name: 'Beta' }, { name: 'Gamma' }];
+    expect(filterByName(items, 'a')).toEqual([{ name: 'Alpha' }, { name: 'Beta' }, { name: 'Gamma' }]);
+  });
+
+  test('isExerciseInDraft detects exercise in session or setlist', () => {
+    const session: DraftSession = {
+      id: '1',
+      notes: null,
+      duration: null,
+      items: [
+        { id: 'a', type: 'exercise', notes: null, tempo: null, exercise: { id: 'ex1', name: '', section: { id: 's', name: '', book: { id: 'b', name: '' } } } },
+      ],
+    };
+    const setlist: DraftSetlist = { id: '2', name: null, description: null, items: [] };
+    expect(isExerciseInDraft('ex1', 'session', session, null)).toBe(true);
+    expect(isExerciseInDraft('ex1', 'setlist', null, setlist)).toBe(false);
+  });
+
+  test('create and find session exercise item', () => {
+    const book: BookWithCountsRow = { id: 'b', name: 'Book', author: '', created_at: '', created_by: '', updated_at: '', exercise_count: 0 };
+    const section: SectionWithCountsRow = { id: 's', name: 'Sec', book_id: 'b', created_at: '', created_by: '', updated_at: '', exercise_count: 0, order: 1 };
+    const exercise: LocalExercise = { id: 'ex1', name: 'Ex', section_id: 's', created_at: '', created_by: '', updated_at: '', filepath: null, goal_tempo: null, order: 1 };
+    const draft: DraftSession = { id: '1', notes: null, duration: null, items: [] };
+    const item = createSessionExerciseItem(exercise, section, book);
+    const updated: DraftSession = { ...draft, items: [item] };
+    expect(findSessionExerciseItemId(updated, 'ex1')).toBe(item.id);
+  });
+
+  test('create and find setlist exercise item', () => {
+    const book: BookWithCountsRow = { id: 'b', name: 'Book', author: '', created_at: '', created_by: '', updated_at: '', exercise_count: 0 };
+    const section: SectionWithCountsRow = { id: 's', name: 'Sec', book_id: 'b', created_at: '', created_by: '', updated_at: '', exercise_count: 0, order: 1 };
+    const exercise: LocalExercise = { id: 'ex1', name: 'Ex', section_id: 's', created_at: '', created_by: '', updated_at: '', filepath: null, goal_tempo: null, order: 1 };
+    const draft: DraftSetlist = { id: '1', name: null, description: null, items: [] };
+    const item = createSetlistExerciseItem(exercise, section, book);
+    const updated: DraftSetlist = { ...draft, items: [item] };
+    expect(findSetlistExerciseItemId(updated, 'ex1')).toBe(item.id);
+  });
+});

--- a/front-end/utils/__tests__/item-progress.test.ts
+++ b/front-end/utils/__tests__/item-progress.test.ts
@@ -1,0 +1,14 @@
+import { filterProgressData } from '@/utils/item-progress';
+import { ItemProgressPoint } from '@/types/stats';
+
+describe('item-progress utils', () => {
+  test('filterProgressData filters and sorts data', () => {
+    const now = Date.now();
+    const data: ItemProgressPoint[] = [
+      { timestamp: now - 1000 * 60 * 60 * 24 * 2, played: 1, at_goal: 0, percent_played: 0, percent_at_goal: 0 },
+      { timestamp: now - 1000 * 60 * 60 * 24 * 10, played: 2, at_goal: 1, percent_played: 0, percent_at_goal: 0 },
+    ];
+    const { filtered } = filterProgressData(data, 'week', now);
+    expect(filtered.length).toBe(1);
+  });
+});

--- a/front-end/utils/__tests__/section-form.test.ts
+++ b/front-end/utils/__tests__/section-form.test.ts
@@ -1,0 +1,29 @@
+import { updateCustomName, updateExerciseCount, updateNamingType } from '@/utils/section-form';
+import { SectionFormData } from '@/types/book';
+
+describe('section-form utils', () => {
+  const baseSection: SectionFormData = {
+    name: 'Sec',
+    exerciseCount: 2,
+    exerciseNaming: 'alpha',
+    customExerciseNames: ['a', 'b'],
+  };
+
+  test('updateExerciseCount adjusts count and names', () => {
+    const result = updateExerciseCount(baseSection, '3', ['a', 'b']);
+    expect(result.exerciseCount).toBe(3);
+    expect(result.customExerciseNames).toEqual(['a', 'b', '']);
+  });
+
+  test('updateNamingType toggles type', () => {
+    const result = updateNamingType(baseSection, 'custom');
+    expect(result.exerciseNaming).toBe('custom');
+    expect(result.customExerciseNames?.length).toBe(2);
+  });
+
+  test('updateCustomName updates name array and section', () => {
+    const { names, section } = updateCustomName(baseSection, ['a', 'b'], 1, 'c');
+    expect(names).toEqual(['a', 'c']);
+    expect(section.customExerciseNames).toEqual(['a', 'c']);
+  });
+});

--- a/front-end/utils/__tests__/session-detail.test.ts
+++ b/front-end/utils/__tests__/session-detail.test.ts
@@ -1,0 +1,67 @@
+import { DraftSession, DraftSessionItem } from '@/types/session';
+import {
+  applyTemposToDraft,
+  formatTime,
+  getItemId,
+  getItemName,
+  initializeTempos,
+  updateDraftItemTempo,
+} from '@/utils/session-detail';
+
+const mockItems: DraftSessionItem[] = [
+  {
+    id: '1',
+    type: 'song',
+    notes: null,
+    tempo: 120,
+    song: { id: 'song1', name: 'Song A' },
+  },
+  {
+    id: '2',
+    type: 'exercise',
+    notes: null,
+    tempo: null,
+    exercise: {
+      id: 'ex1',
+      name: 'Ex 1',
+      section: { id: 'sec1', name: 'Sec', book: { id: 'book1', name: 'Book' } },
+    },
+  },
+];
+
+const mockDraft: DraftSession = {
+  id: 'draft1',
+  notes: null,
+  duration: null,
+  items: mockItems,
+};
+
+describe('session-detail utils', () => {
+  test('formatTime', () => {
+    expect(formatTime(0)).toBe('00:00');
+    expect(formatTime(125)).toBe('02:05');
+  });
+
+  test('initializeTempos', () => {
+    expect(initializeTempos(mockItems)).toEqual({ '1': '120', '2': '' });
+  });
+
+  test('updateDraftItemTempo', () => {
+    const updated = updateDraftItemTempo(mockItems, '2', '90');
+    expect(updated[1].tempo).toBe(90);
+  });
+
+  test('applyTemposToDraft', () => {
+    const result = applyTemposToDraft(mockDraft, { '1': '110', '2': '80' }, 30);
+    expect(result.duration).toBe(30);
+    expect(result.items[0].tempo).toBe(110);
+    expect(result.items[1].tempo).toBe(80);
+  });
+
+  test('getItemId and getItemName', () => {
+    expect(getItemId(mockItems[0])).toBe('song1');
+    expect(getItemName(mockItems[0])).toBe('Song A');
+    expect(getItemId(mockItems[1])).toBe('ex1');
+    expect(getItemName(mockItems[1])).toBe('Ex 1');
+  });
+});

--- a/front-end/utils/__tests__/song-edit.test.ts
+++ b/front-end/utils/__tests__/song-edit.test.ts
@@ -1,0 +1,20 @@
+import { fuzzySearchArtists } from '@/utils/song-edit';
+import { LocalArtist } from '@/types/artist';
+
+describe('song-edit utils', () => {
+  test('fuzzySearchArtists returns matching artists', () => {
+    const artists: LocalArtist[] = [
+      { id: '1', name: 'Bruno Mars', created_at: '', created_by: '', updated_at: '' },
+      { id: '2', name: 'Miles Davis', created_at: '', created_by: '', updated_at: '' },
+    ];
+    const result = fuzzySearchArtists(artists, 'bru');
+    expect(result[0].name).toBe('Bruno Mars');
+  });
+
+  test('returns empty array for empty query', () => {
+    const artists: LocalArtist[] = [
+      { id: '1', name: 'Bruno Mars', created_at: '', created_by: '', updated_at: '' },
+    ];
+    expect(fuzzySearchArtists(artists, '')).toEqual([]);
+  });
+});

--- a/front-end/utils/books-tab.ts
+++ b/front-end/utils/books-tab.ts
@@ -1,0 +1,66 @@
+import { DraftSession, DraftSessionItem } from '@/types/session';
+import { DraftSetlist, DraftSetlistItem } from '@/types/setlist';
+import { LocalExercise } from '@/types/exercise';
+import { BookWithCountsRow } from '@/types/book';
+import { SectionWithCountsRow } from '@/types/section';
+import { exerciseToDraftSessionItem } from '@/utils/draft-session';
+import { exerciseToDraftSetlistItem } from '@/utils/draft-setlist';
+
+export function filterByName<T extends { name?: string }>(items: T[], query: string): T[] {
+  return items.filter(item => item.name?.toLowerCase().includes(query.toLowerCase()));
+}
+
+export function isExerciseInDraft(
+  exerciseId: string,
+  mode: 'session' | 'setlist',
+  draftSession: DraftSession | null,
+  draftSetlist: DraftSetlist | null,
+): boolean {
+  if (mode === 'session' && draftSession) {
+    return draftSession.items.some(
+      (item) => item.type === 'exercise' && item.exercise?.id === exerciseId
+    );
+  }
+  if (mode === 'setlist' && draftSetlist) {
+    return draftSetlist.items.some(
+      (item) => item.type === 'exercise' && item.exercise?.id === exerciseId
+    );
+  }
+  return false;
+}
+
+export function createSessionExerciseItem(
+  exercise: LocalExercise,
+  section: SectionWithCountsRow,
+  book: BookWithCountsRow,
+): DraftSessionItem {
+  return exerciseToDraftSessionItem(exercise, section, book);
+}
+
+export function createSetlistExerciseItem(
+  exercise: LocalExercise,
+  section: SectionWithCountsRow,
+  book: BookWithCountsRow,
+): DraftSetlistItem {
+  return exerciseToDraftSetlistItem(exercise, section, book);
+}
+
+export function findSessionExerciseItemId(
+  draft: DraftSession,
+  exerciseId: string,
+): string | undefined {
+  const item = draft.items.find(
+    (i) => i.type === 'exercise' && i.exercise?.id === exerciseId,
+  );
+  return item?.id;
+}
+
+export function findSetlistExerciseItemId(
+  draft: DraftSetlist,
+  exerciseId: string,
+): string | undefined {
+  const item = draft.items.find(
+    (i) => i.type === 'exercise' && i.exercise?.id === exerciseId,
+  );
+  return item?.id;
+}

--- a/front-end/utils/item-progress.ts
+++ b/front-end/utils/item-progress.ts
@@ -1,0 +1,21 @@
+import { ItemProgressPoint, TimeRange } from '@/types/stats';
+import { calculateCutoffDate } from './date-time';
+
+export function filterProgressData(
+  data: ItemProgressPoint[],
+  timeRange: TimeRange,
+  now: number = Date.now()
+): { filtered: ItemProgressPoint[]; cutoffDate: number } {
+  const cutoffDate =
+    timeRange === 'all' && data.length > 0
+      ? Math.min(...data.map(point => point.timestamp))
+      : calculateCutoffDate(timeRange).getTime();
+
+  const filtered = data
+    .filter(point => point.timestamp >= cutoffDate)
+    .filter(point => point.timestamp <= now)
+    .sort((a, b) => a.timestamp - b.timestamp)
+    .map(point => ({ ...point, timestamp: point.timestamp }));
+
+  return { filtered, cutoffDate };
+}

--- a/front-end/utils/section-form.ts
+++ b/front-end/utils/section-form.ts
@@ -1,0 +1,36 @@
+import { ExerciseNamingType, SectionFormData } from '@/types/book';
+
+export function updateExerciseCount(
+  section: SectionFormData,
+  value: string,
+  currentNames: string[]
+): SectionFormData {
+  const count = parseInt(value) || 0;
+  return {
+    ...section,
+    exerciseCount: count,
+    customExerciseNames: Array(count).fill('').map((_, i) => currentNames[i] || ''),
+  };
+}
+
+export function updateNamingType(section: SectionFormData, type: ExerciseNamingType): SectionFormData {
+  return {
+    ...section,
+    exerciseNaming: type,
+    customExerciseNames: type === 'custom' ? Array(section.exerciseCount).fill('') : undefined,
+  };
+}
+
+export function updateCustomName(
+  section: SectionFormData,
+  currentNames: string[],
+  index: number,
+  value: string
+): { names: string[]; section: SectionFormData } {
+  const newNames = [...currentNames];
+  newNames[index] = value;
+  return {
+    names: newNames,
+    section: { ...section, customExerciseNames: newNames },
+  };
+}

--- a/front-end/utils/session-detail.ts
+++ b/front-end/utils/session-detail.ts
@@ -1,0 +1,45 @@
+import { DraftSession, DraftSessionItem } from '@/types/session';
+
+export function formatTime(seconds: number): string {
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes.toString().padStart(2, '0')}:${remainingSeconds.toString().padStart(2, '0')}`;
+}
+
+export function initializeTempos(items: DraftSessionItem[]): Record<string, string> {
+  return Object.fromEntries(items.map(item => [item.id, item.tempo?.toString() || '']));
+}
+
+export function updateDraftItemTempo(items: DraftSessionItem[], itemId: string, text: string): DraftSessionItem[] {
+  return items.map(item =>
+    item.id === itemId ? { ...item, tempo: text ? parseInt(text, 10) || null : null } : item
+  );
+}
+
+export function applyTemposToDraft(draft: DraftSession, tempos: Record<string, string>, elapsed: number): DraftSession {
+  const items = draft.items.map(item => {
+    const current = tempos[item.id];
+    return { ...item, tempo: current ? parseInt(current, 10) || null : null };
+  });
+  return { ...draft, duration: elapsed, items };
+}
+
+export function getItemId(item: DraftSessionItem): string {
+  if (item.type === 'exercise' && item.exercise) {
+    return item.exercise.id;
+  }
+  if (item.type === 'song' && item.song) {
+    return item.song.id;
+  }
+  return '';
+}
+
+export function getItemName(item: DraftSessionItem): string {
+  if (item.type === 'exercise' && item.exercise) {
+    return item.exercise.name || 'Untitled Exercise';
+  }
+  if (item.type === 'song' && item.song) {
+    return item.song.name || 'Untitled Song';
+  }
+  return '';
+}

--- a/front-end/utils/song-edit.ts
+++ b/front-end/utils/song-edit.ts
@@ -1,0 +1,17 @@
+import Fuse from 'fuse.js';
+import { LocalArtist } from '@/types/artist';
+
+export function fuzzySearchArtists(artists: LocalArtist[], query: string): LocalArtist[] {
+  if (!query) return [];
+  const fuse = new Fuse(artists, {
+    keys: ['name'],
+    threshold: 0.3,
+    distance: 100,
+    minMatchCharLength: 1,
+    shouldSort: true,
+    includeScore: true,
+  });
+  return fuse.search(query)
+    .filter(result => result.score && result.score < 0.6)
+    .map(result => result.item);
+}


### PR DESCRIPTION
## Summary
- extract helper logic from large components to dedicated utility modules
- add Jest tests for new utils
- refine BooksTab helpers to avoid huge parameter lists

## Testing
- `npm test --prefix front-end`


------
https://chatgpt.com/codex/tasks/task_e_68491b197150832b9e235bf24d93b6e3