### PR TITLE
Refactor action buttons

### DIFF
--- a/front-end/app/(tabs)/sessions/index.tsx
+++ b/front-end/app/(tabs)/sessions/index.tsx
@@ -1,11 +1,10 @@
 import { PracticeSessionSummaryCard } from '@/components/sessions/PracticeSessionSummaryCard';
-import { Text } from '@/components/ui/text';
+import { ActionButton } from '@/components/ui/action-button';
 import { useSessionsStore } from '@/stores/session-store';
 import { router, useNavigation } from 'expo-router';
 import { Plus } from 'lucide-react-native';
-import { ActionButton } from '@/components/ui/action-button';
 import { useEffect } from 'react';
-import { Pressable, ScrollView, View } from 'react-native';
+import { ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function RecentSessionsPage() {

--- a/front-end/app/(tabs)/sessions/index.tsx
+++ b/front-end/app/(tabs)/sessions/index.tsx
@@ -3,6 +3,7 @@ import { Text } from '@/components/ui/text';
 import { useSessionsStore } from '@/stores/session-store';
 import { router, useNavigation } from 'expo-router';
 import { Plus } from 'lucide-react-native';
+import { ActionButton } from '@/components/ui/action-button';
 import { useEffect } from 'react';
 import { Pressable, ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -32,15 +33,12 @@ export default function RecentSessionsPage() {
       </ScrollView>
 
       <View className="absolute bottom-4 w-full max-w-md px-4 ">
-        <Pressable
-          className="flex-row items-center justify-center bg-primary rounded-xl py-4 shadow-md active:opacity-80"
+        <ActionButton
+          text="Start Session"
+          icon={<Plus size={24} color="white" />}
           onPress={() => router.push('/sessions/make-session')}
-        >
-          <Plus size={24} color="white" className="mr-2" />
-          <Text variant="title-2xl" className="text-white">
-            Start Session
-          </Text>
-        </Pressable>
+          textVariant="title-2xl"
+        />
       </View>
     </SafeAreaView>
   );

--- a/front-end/app/(tabs)/sessions/make-session.tsx
+++ b/front-end/app/(tabs)/sessions/make-session.tsx
@@ -4,6 +4,7 @@ import { useDraftSessionsStore } from '@/stores/draft-sessions-store';
 import { createNewDraft } from '@/utils/draft-session';
 import { router } from 'expo-router';
 import { Play, Plus } from 'lucide-react-native';
+import { ActionButton } from '@/components/ui/action-button';
 import { useEffect } from 'react';
 import { Pressable, SafeAreaView, ScrollView, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -52,15 +53,12 @@ export default function MakeSessionPage() {
           </Pressable>
 
           {/* Start Practice Button */}
-          <Pressable
-            className="flex-1 flex-row items-center justify-center bg-primary rounded-xl py-4 shadow-md active:opacity-80"
+          <ActionButton
+            text="Start"
+            icon={<Play size={20} color="white" />}
             onPress={() => router.push('/session-detail/active-session')}
-          >
-            <Play size={20} color="white" className="mr-2" />
-            <Text variant="body-semibold" className="text-white">
-              Start
-            </Text>
-          </Pressable>
+            className="flex-1"
+          />
         </View>
       </View>
     </SafeAreaView>

--- a/front-end/app/(tabs)/setlists/add-item.tsx
+++ b/front-end/app/(tabs)/setlists/add-item.tsx
@@ -1,13 +1,12 @@
 import { BooksTab } from '@/components/shared/BooksTab';
 import { ReusableTabView, TabValue } from '@/components/shared/reusable-tab-view';
 import { SongsTab } from '@/components/shared/SongsTab';
-import { TabsContent } from '@/components/ui/tabs';
-import { Text } from '@/components/ui/text';
 import { ActionButton } from '@/components/ui/action-button';
+import { TabsContent } from '@/components/ui/tabs';
 import { router } from 'expo-router';
 import { Check } from 'lucide-react-native';
 import { useState } from 'react';
-import { Pressable, ScrollView, TextInput, View } from 'react-native';
+import { ScrollView, TextInput, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 const ADD_ITEM_TABS: readonly TabValue[] = ['books', 'songs'] as const;

--- a/front-end/app/(tabs)/setlists/add-item.tsx
+++ b/front-end/app/(tabs)/setlists/add-item.tsx
@@ -3,6 +3,7 @@ import { ReusableTabView, TabValue } from '@/components/shared/reusable-tab-view
 import { SongsTab } from '@/components/shared/SongsTab';
 import { TabsContent } from '@/components/ui/tabs';
 import { Text } from '@/components/ui/text';
+import { ActionButton } from '@/components/ui/action-button';
 import { router } from 'expo-router';
 import { Check } from 'lucide-react-native';
 import { useState } from 'react';
@@ -40,15 +41,12 @@ export default function AddItemScreen() {
         className="absolute bottom-0 left-0 right-0 bg-white border-t border-slate-200"
         style={{ paddingBottom: insets.bottom }}
       >
-        <Pressable
-          className="mx-4 my-4 flex-row items-center justify-center bg-primary rounded-xl py-4 shadow-md active:opacity-80"
+        <ActionButton
+          text="Done"
+          icon={<Check size={20} color="white" />}
           onPress={() => router.back()}
-        >
-          <Check size={20} color="white" className="mr-2" />
-          <Text variant="body-semibold" className="text-white">
-            Done
-          </Text>
-        </Pressable>
+          className="mx-4 my-4"
+        />
       </View>
     </View>
   );

--- a/front-end/app/(tabs)/setlists/edit/[id].tsx
+++ b/front-end/app/(tabs)/setlists/edit/[id].tsx
@@ -3,6 +3,7 @@ import { ThemedIcon } from '@/components/icons/ThemedIcon';
 import { ItemRow } from '@/components/setlists/ItemRow';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
+import { ActionButton } from '@/components/ui/action-button';
 import { useDraftSetlistsStore } from '@/stores/draft-setlist-store';
 import { useSetlistsStore } from '@/stores/setlist-store';
 import { DraftSetlistItem } from '@/types/setlist';
@@ -153,16 +154,13 @@ export default function EditSetlistPage() {
           </Pressable>
 
           {/* Save Setlist Button */}
-          <Pressable
-            className="flex-1 flex-row items-center justify-center bg-primary rounded-xl py-4 shadow-md active:opacity-80 gap-x-1"
+          <ActionButton
+            text="Save"
+            icon={<ThemedIcon name="Save" size={20} color="white" />}
             onPress={handleSaveSetlist}
             disabled={!draftSetlist.name}
-          >
-            <ThemedIcon name="Save" size={20} color="white" />
-            <Text variant="body-semibold" className="text-white">
-              Save
-            </Text>
-          </Pressable>
+            className="flex-1 gap-x-1"
+          />
         </View>
       </View>
     </View>

--- a/front-end/app/library-forms/add-book.tsx
+++ b/front-end/app/library-forms/add-book.tsx
@@ -10,6 +10,7 @@ import { toRomanNumeral } from '@/utils/string';
 import { useRouter } from 'expo-router';
 import React, { useState } from 'react';
 import { ActivityIndicator, Pressable, View } from 'react-native';
+import { ActionButton } from '@/components/ui/action-button';
 import { ScrollView } from 'react-native-gesture-handler';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -142,24 +143,14 @@ export default function AddBookPage() {
             ))}
           </View>
 
-          <Pressable
+          <ActionButton
             onPress={handleSaveBook}
             disabled={isSaving}
-            className={`rounded-xl py-3 items-center flex-row justify-center ${isSaving ? 'bg-primary/70' : 'bg-primary'}`}
-          >
-            {isSaving ? (
-              <>
-                <ActivityIndicator color="white" className="mr-2" />
-                <Text variant="body-bold" className="text-xl text-white">
-                  Saving...
-                </Text>
-              </>
-            ) : (
-              <Text variant="body-bold" className="text-xl text-white">
-                Save Book
-              </Text>
-            )}
-          </Pressable>
+            className={isSaving ? 'bg-primary/70' : undefined}
+            textVariant="body-bold"
+            text={isSaving ? 'Saving...' : 'Save Book'}
+            icon={isSaving ? <ActivityIndicator color="white" /> : undefined}
+          />
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/front-end/app/library-forms/add-song.tsx
+++ b/front-end/app/library-forms/add-song.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'expo-router';
 import Fuse from 'fuse.js';
 import React, { useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, Pressable, View } from 'react-native';
+import { ActionButton } from '@/components/ui/action-button';
 import { ScrollView } from 'react-native-gesture-handler';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -129,24 +130,14 @@ export default function AddSongPage() {
             placeholder="e.g., 120"
             keyboardType="numeric"
           />
-          <Pressable
+          <ActionButton
             onPress={handleSaveSong}
             disabled={isSaving}
-            className={`bg-primary rounded-xl py-3 items-center flex-row justify-center ${isSaving ? 'bg-primary/70' : 'bg-primary'}`}
-          >
-            {isSaving ? (
-              <>
-                <ActivityIndicator color="white" className="mr-2" />
-                <Text variant="body-bold" className="text-white">
-                  Saving...
-                </Text>
-              </>
-            ) : (
-              <Text variant="body-bold" className="text-white">
-                Save Song
-              </Text>
-            )}
-          </Pressable>
+            className={isSaving ? 'bg-primary/70' : undefined}
+            textVariant="body-bold"
+            text={isSaving ? 'Saving...' : 'Save Song'}
+            icon={isSaving ? <ActivityIndicator color="white" /> : undefined}
+          />
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/front-end/app/library-forms/add-song.tsx
+++ b/front-end/app/library-forms/add-song.tsx
@@ -1,4 +1,5 @@
 import { TextInputWithLabel } from '@/components/forms/TextInputWithLabel';
+import { ActionButton } from '@/components/ui/action-button';
 import { Text } from '@/components/ui/text';
 import { useArtistsStore } from '@/stores/artist-store';
 import { useSongsStore } from '@/stores/song-store';
@@ -7,7 +8,6 @@ import { useRouter } from 'expo-router';
 import Fuse from 'fuse.js';
 import React, { useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, Pressable, View } from 'react-native';
-import { ActionButton } from '@/components/ui/action-button';
 import { ScrollView } from 'react-native-gesture-handler';
 import { SafeAreaView } from 'react-native-safe-area-context';
 

--- a/front-end/app/library-forms/edit-artist/[artistId].tsx
+++ b/front-end/app/library-forms/edit-artist/[artistId].tsx
@@ -6,6 +6,7 @@ import { useArtistsStore } from '@/stores/artist-store';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useEffect, useState } from 'react';
 import { ActivityIndicator, Alert, Pressable, View } from 'react-native';
+import { ActionButton } from '@/components/ui/action-button';
 import { ScrollView } from 'react-native-gesture-handler';
 
 export default function EditArtistPage() {
@@ -81,24 +82,14 @@ export default function EditArtistPage() {
             </View>
           </Pressable>
 
-          <Pressable
+          <ActionButton
             onPress={handleSaveArtist}
             disabled={isSaving}
-            className={`rounded-xl py-3 items-center flex-row justify-center ${isSaving ? 'bg-primary/70' : 'bg-primary'}`}
-          >
-            {isSaving ? (
-              <>
-                <ActivityIndicator color="white" className="mr-2" />
-                <Text variant="body-bold" className="text-white">
-                  Saving...
-                </Text>
-              </>
-            ) : (
-              <Text variant="body-bold" className="text-white">
-                Save Artist
-              </Text>
-            )}
-          </Pressable>
+            className={isSaving ? 'bg-primary/70' : undefined}
+            textVariant="body-bold"
+            text={isSaving ? 'Saving...' : 'Save Artist'}
+            icon={isSaving ? <ActivityIndicator color="white" /> : undefined}
+          />
         </View>
       </ScrollView>
     </View>

--- a/front-end/app/library-forms/edit-book/[bookId].tsx
+++ b/front-end/app/library-forms/edit-book/[bookId].tsx
@@ -10,6 +10,7 @@ import { useSectionsStore } from '@/stores/section-store';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useEffect, useState } from 'react';
 import { ActivityIndicator, Alert, Pressable, View } from 'react-native';
+import { ActionButton } from '@/components/ui/action-button';
 import { ScrollView } from 'react-native-gesture-handler';
 
 export type EditableSection = {
@@ -175,24 +176,14 @@ export default function EditBookPage() {
           </View>
         </View>
 
-        <Pressable
+        <ActionButton
           onPress={handleSaveBook}
           disabled={isSaving}
-          className={`rounded-xl py-3 items-center flex-row justify-center ${isSaving ? 'bg-primary/70' : 'bg-primary'}`}
-        >
-          {isSaving ? (
-            <>
-              <ActivityIndicator color="white" className="mr-2" />
-              <Text variant="body-bold" className="text-white">
-                Saving...
-              </Text>
-            </>
-          ) : (
-            <Text variant="body-bold" className="text-white">
-              Save Book
-            </Text>
-          )}
-        </Pressable>
+          className={isSaving ? 'bg-primary/70' : undefined}
+          textVariant="body-bold"
+          text={isSaving ? 'Saving...' : 'Save Book'}
+          icon={isSaving ? <ActivityIndicator color="white" /> : undefined}
+        />
       </ScrollView>
     </View>
   );

--- a/front-end/app/library-forms/edit-section/[sectionId].tsx
+++ b/front-end/app/library-forms/edit-section/[sectionId].tsx
@@ -11,6 +11,7 @@ import { useSectionsStore } from '@/stores/section-store';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useEffect, useState } from 'react';
 import { ActivityIndicator, Alert, Pressable, View } from 'react-native';
+import { ActionButton } from '@/components/ui/action-button';
 import { ScrollView } from 'react-native-gesture-handler';
 
 export type EditableExercise = {
@@ -167,24 +168,14 @@ export default function EditSectionPage() {
             </View>
           </View>
 
-          <Pressable
+          <ActionButton
             onPress={handleSaveSection}
             disabled={isSaving}
-            className={`rounded-xl py-3 items-center flex-row justify-center ${isSaving ? 'bg-primary/70' : 'bg-primary'}`}
-          >
-            {isSaving ? (
-              <>
-                <ActivityIndicator color="white" className="mr-2" />
-                <Text variant="body-bold" className="text-white">
-                  Saving...
-                </Text>
-              </>
-            ) : (
-              <Text variant="body-bold" className="text-white">
-                Save Section
-              </Text>
-            )}
-          </Pressable>
+            className={isSaving ? 'bg-primary/70' : undefined}
+            textVariant="body-bold"
+            text={isSaving ? 'Saving...' : 'Save Section'}
+            icon={isSaving ? <ActivityIndicator color="white" /> : undefined}
+          />
         </View>
       </ScrollView>
     </View>

--- a/front-end/app/library-forms/edit-song/[songId].tsx
+++ b/front-end/app/library-forms/edit-song/[songId].tsx
@@ -9,6 +9,7 @@ import { fuzzySearchArtists } from '@/utils/song-edit';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, Alert, Pressable, View } from 'react-native';
+import { ActionButton } from '@/components/ui/action-button';
 import { ScrollView } from 'react-native-gesture-handler';
 
 export default function EditSongPage() {
@@ -135,24 +136,14 @@ export default function EditSongPage() {
             </View>
           </Pressable>
 
-          <Pressable
+          <ActionButton
             onPress={handleSaveSong}
             disabled={isSaving}
-            className={`rounded-xl py-3 items-center flex-row justify-center ${isSaving ? 'bg-primary/70' : 'bg-primary'}`}
-          >
-            {isSaving ? (
-              <>
-                <ActivityIndicator color="white" className="mr-2" />
-                <Text variant="body-bold" className="text-white">
-                  Saving...
-                </Text>
-              </>
-            ) : (
-              <Text variant="body-bold" className="text-white">
-                Save Song
-              </Text>
-            )}
-          </Pressable>
+            className={isSaving ? 'bg-primary/70' : undefined}
+            textVariant="body-bold"
+            text={isSaving ? 'Saving...' : 'Save Song'}
+            icon={isSaving ? <ActivityIndicator color="white" /> : undefined}
+          />
         </View>
       </ScrollView>
     </View>

--- a/front-end/app/session-detail/active-session.tsx
+++ b/front-end/app/session-detail/active-session.tsx
@@ -13,6 +13,7 @@ import {
 import { router } from 'expo-router';
 import { useEffect, useState } from 'react';
 import { Pressable, ScrollView, View } from 'react-native';
+import { ActionButton } from '@/components/ui/action-button';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function ActiveSessionPage() {
@@ -138,15 +139,13 @@ export default function ActiveSessionPage() {
             Add Item
           </Text>
         </Pressable>
-        <Pressable
-          className="mx-4 my-4 flex-1 flex-row items-center justify-center bg-red-500 rounded-xl py-4 active:opacity-80"
+        <ActionButton
+          text="End Session"
+          icon={<ThemedIcon name="Check" size={20} color="white" />}
           onPress={handleEndSession}
-        >
-          <ThemedIcon name="Check" size={20} color="white" className="mr-2" />
-          <Text variant="body-semibold" className="text-white text-lg">
-            End Session
-          </Text>
-        </Pressable>
+          className="mx-4 my-4 flex-1"
+          textVariant="body-semibold"
+        />
       </View>
     </SafeAreaView>
   );

--- a/front-end/app/session-detail/add-item-to-session.tsx
+++ b/front-end/app/session-detail/add-item-to-session.tsx
@@ -2,13 +2,12 @@ import { SetlistsTab } from '@/components/sessions/SetlistsTab';
 import { BooksTab } from '@/components/shared/BooksTab';
 import { ReusableTabView, TabValue } from '@/components/shared/reusable-tab-view';
 import { SongsTab } from '@/components/shared/SongsTab';
+import { ActionButton } from '@/components/ui/action-button';
 import { TabsContent } from '@/components/ui/tabs';
-import { Text } from '@/components/ui/text';
 import { router } from 'expo-router';
 import { Check } from 'lucide-react-native';
-import { ActionButton } from '@/components/ui/action-button';
 import { useState } from 'react';
-import { Pressable, SafeAreaView, ScrollView, TextInput, View } from 'react-native';
+import { SafeAreaView, ScrollView, TextInput, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 const SESSION_TABS: readonly TabValue[] = ['setlists', 'books', 'songs'] as const;

--- a/front-end/app/session-detail/add-item-to-session.tsx
+++ b/front-end/app/session-detail/add-item-to-session.tsx
@@ -6,6 +6,7 @@ import { TabsContent } from '@/components/ui/tabs';
 import { Text } from '@/components/ui/text';
 import { router } from 'expo-router';
 import { Check } from 'lucide-react-native';
+import { ActionButton } from '@/components/ui/action-button';
 import { useState } from 'react';
 import { Pressable, SafeAreaView, ScrollView, TextInput, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -55,15 +56,12 @@ export default function AddItemToSessionScreen() {
         className="absolute bottom-4 left-0 right-0 bg-white "
         style={{ paddingBottom: insets.bottom }}
       >
-        <Pressable
-          className="mx-4 my-4 flex-row items-center justify-center bg-primary rounded-xl py-4 shadow-md active:opacity-80"
+        <ActionButton
+          text="Done"
+          icon={<Check size={22} color="white" />}
           onPress={() => router.back()}
-        >
-          <Check size={22} color="white" className="mr-2" />
-          <Text variant="body-semibold" className="text-white ml-1">
-            Done
-          </Text>
-        </Pressable>
+          className="mx-4 my-4"
+        />
       </View>
     </SafeAreaView>
   );

--- a/front-end/components/ui/action-button.tsx
+++ b/front-end/components/ui/action-button.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { Pressable, type PressableProps } from 'react-native';
+import { Text, type TextProps } from './text';
+import { cn } from '@/utils/tailwind-utils';
+
+interface ActionButtonProps extends PressableProps {
+  text: string;
+  icon?: React.ReactElement;
+  textVariant?: TextProps['variant'];
+}
+
+export function ActionButton({
+  text,
+  icon,
+  textVariant = 'body-semibold',
+  className,
+  ...props
+}: ActionButtonProps) {
+  const renderedIcon = React.useMemo(() => {
+    if (!icon) return null;
+    return React.cloneElement(icon, {
+      className: cn(icon.props.className, 'mr-2'),
+    });
+  }, [icon]);
+
+  return (
+    <Pressable
+      className={cn(
+        'flex-row items-center justify-center bg-primary rounded-xl py-4 shadow-md active:opacity-80',
+        className,
+      )}
+      {...props}
+    >
+      {renderedIcon}
+      <Text variant={textVariant} className="text-white">
+        {text}
+      </Text>
+    </Pressable>
+  );
+}

--- a/front-end/components/ui/action-button.tsx
+++ b/front-end/components/ui/action-button.tsx
@@ -1,11 +1,11 @@
+import { Text, type TextProps } from '@/components/ui/text';
+import { cn } from '@/utils/tailwind-utils';
 import * as React from 'react';
 import { Pressable, type PressableProps } from 'react-native';
-import { Text, type TextProps } from './text';
-import { cn } from '@/utils/tailwind-utils';
 
 interface ActionButtonProps extends PressableProps {
   text: string;
-  icon?: React.ReactElement;
+  icon?: React.ReactElement<{ className?: string }>;
   textVariant?: TextProps['variant'];
 }
 
@@ -27,7 +27,7 @@ export function ActionButton({
     <Pressable
       className={cn(
         'flex-row items-center justify-center bg-primary rounded-xl py-4 shadow-md active:opacity-80',
-        className,
+        className
       )}
       {...props}
     >

--- a/front-end/components/ui/text.tsx
+++ b/front-end/components/ui/text.tsx
@@ -6,7 +6,7 @@ import { Text as RNText } from 'react-native';
 
 const TextClassContext = React.createContext<string | undefined>(undefined);
 
-interface TextProps extends SlottableTextProps {
+export interface TextProps extends SlottableTextProps {
   variant?:
     | 'body'
     | 'body-semibold'


### PR DESCRIPTION
## Summary
- add `ActionButton` component for consistent call-to-action buttons
- replace red call-to-action `Pressable` usages with `ActionButton`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859f3faadb0832bb2c0499a438a70a9