### PR TITLE
Refactor repeated add/delete buttons

### DIFF
--- a/front-end/app/(tabs)/sessions/make-session.tsx
+++ b/front-end/app/(tabs)/sessions/make-session.tsx
@@ -3,7 +3,8 @@ import { Text } from '@/components/ui/text';
 import { useDraftSessionsStore } from '@/stores/draft-sessions-store';
 import { createNewDraft } from '@/utils/draft-session';
 import { router } from 'expo-router';
-import { Play, Plus } from 'lucide-react-native';
+import { Play } from 'lucide-react-native';
+import { AddItemButton } from '@/components/shared/AddItemButton';
 import { useEffect } from 'react';
 import { Pressable, SafeAreaView, ScrollView, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -41,15 +42,13 @@ export default function MakeSessionPage() {
       >
         <View className="flex-row gap-x-4 mt-4 mx-4">
           {/* Add Items Button */}
-          <Pressable
+          <AddItemButton
             className="flex-1 flex-row items-center justify-center bg-slate-100 rounded-xl py-4 active:opacity-80"
+            iconSize={20}
+            iconColor="slate-900"
             onPress={() => router.push('/session-detail/add-item-to-session')}
-          >
-            <Plus size={20} className="mr-2 text-slate-900" />
-            <Text variant="body-semibold" className="text-slate-900">
-              Add Items
-            </Text>
-          </Pressable>
+            label="Add Items"
+          />
 
           {/* Start Practice Button */}
           <Pressable

--- a/front-end/app/(tabs)/setlists/edit/[id].tsx
+++ b/front-end/app/(tabs)/setlists/edit/[id].tsx
@@ -1,4 +1,5 @@
 import { TextInputWithLabel } from '@/components/forms/TextInputWithLabel';
+import { AddItemButton } from '@/components/shared/AddItemButton';
 import { ThemedIcon } from '@/components/icons/ThemedIcon';
 import { ItemRow } from '@/components/setlists/ItemRow';
 import { Button } from '@/components/ui/button';
@@ -142,15 +143,13 @@ export default function EditSetlistPage() {
       <View className="absolute bottom-0 left-0 right-0 bg-white border-t border-slate-200">
         <View className="flex-row gap-x-4 m-4">
           {/* Add Items Button */}
-          <Pressable
+          <AddItemButton
             className="flex-1 flex-row items-center justify-center bg-slate-100 rounded-xl py-4 active:opacity-80 gap-x-1"
+            iconSize={20}
+            iconColor="slate-900"
             onPress={handleOpenAddItemModal}
-          >
-            <ThemedIcon name="Plus" size={20} color="slate-900" />
-            <Text variant="body-semibold" className="text-slate-900">
-              Add Item
-            </Text>
-          </Pressable>
+            label="Add Item"
+          />
 
           {/* Save Setlist Button */}
           <Pressable

--- a/front-end/app/(tabs)/setlists/edit/[id].tsx
+++ b/front-end/app/(tabs)/setlists/edit/[id].tsx
@@ -1,17 +1,17 @@
 import { TextInputWithLabel } from '@/components/forms/TextInputWithLabel';
-import { AddItemButton } from '@/components/shared/AddItemButton';
 import { ThemedIcon } from '@/components/icons/ThemedIcon';
 import { ItemRow } from '@/components/setlists/ItemRow';
+import { AddItemButton } from '@/components/shared/AddItemButton';
+import { ActionButton } from '@/components/ui/action-button';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
-import { ActionButton } from '@/components/ui/action-button';
 import { useDraftSetlistsStore } from '@/stores/draft-setlist-store';
 import { useSetlistsStore } from '@/stores/setlist-store';
 import { DraftSetlistItem } from '@/types/setlist';
 import { createDraftFromSetlist, createNewDraft } from '@/utils/draft-setlist';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useEffect } from 'react';
-import { Alert, Pressable, View } from 'react-native';
+import { Alert, View } from 'react-native';
 import DraggableFlatList, {
   RenderItemParams,
   ScaleDecorator,
@@ -145,7 +145,7 @@ export default function EditSetlistPage() {
         <View className="flex-row gap-x-4 m-4">
           {/* Add Items Button */}
           <AddItemButton
-            className="flex-1 flex-row items-center justify-center bg-slate-100 rounded-xl py-4 active:opacity-80 gap-x-1"
+            className="flex-1"
             iconSize={20}
             iconColor="slate-900"
             onPress={handleOpenAddItemModal}

--- a/front-end/app/library-forms/edit-artist/[artistId].tsx
+++ b/front-end/app/library-forms/edit-artist/[artistId].tsx
@@ -1,5 +1,5 @@
 import { TextInputWithLabel } from '@/components/forms/TextInputWithLabel';
-import { ThemedIcon } from '@/components/icons/ThemedIcon';
+import { DeleteButton } from '@/components/shared/DeleteButton';
 import { Text } from '@/components/ui/text';
 import { deleteArtist, updateArtist } from '@/lib/supabase/artist';
 import { useArtistsStore } from '@/stores/artist-store';
@@ -72,14 +72,7 @@ export default function EditArtistPage() {
             onChangeText={setArtistName}
             placeholder="Example Artist"
           />
-          <Pressable onPress={handleDeleteArtist} className="self-start">
-            <View className="flex-row items-center gap-x-2 bg-red-100 rounded-xl py-2 px-4 border border-red-500">
-              <ThemedIcon name="TriangleAlert" size={24} color="red-500" />
-              <Text variant="body-semibold" className="text-red-500">
-                Delete Artist
-              </Text>
-            </View>
-          </Pressable>
+          <DeleteButton onPress={handleDeleteArtist} label="Delete Artist" />
 
           <Pressable
             onPress={handleSaveArtist}

--- a/front-end/app/library-forms/edit-artist/[artistId].tsx
+++ b/front-end/app/library-forms/edit-artist/[artistId].tsx
@@ -1,12 +1,12 @@
 import { TextInputWithLabel } from '@/components/forms/TextInputWithLabel';
 import { DeleteButton } from '@/components/shared/DeleteButton';
+import { ActionButton } from '@/components/ui/action-button';
 import { Text } from '@/components/ui/text';
 import { deleteArtist, updateArtist } from '@/lib/supabase/artist';
 import { useArtistsStore } from '@/stores/artist-store';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useEffect, useState } from 'react';
-import { ActivityIndicator, Alert, Pressable, View } from 'react-native';
-import { ActionButton } from '@/components/ui/action-button';
+import { ActivityIndicator, Alert, View } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 
 export default function EditArtistPage() {

--- a/front-end/app/library-forms/edit-book/[bookId].tsx
+++ b/front-end/app/library-forms/edit-book/[bookId].tsx
@@ -1,6 +1,7 @@
 import { InputWithDelete } from '@/components/forms/InputWithDelete';
 import { TextInputWithLabel } from '@/components/forms/TextInputWithLabel';
-import { ThemedIcon } from '@/components/icons/ThemedIcon';
+import { DeleteButton } from '@/components/shared/DeleteButton';
+import { AddItemButton } from '@/components/shared/AddItemButton';
 import { Separator } from '@/components/shared/Separator';
 import { Text } from '@/components/ui/text';
 import { deleteBook, updateBook } from '@/lib/supabase/book';
@@ -139,14 +140,7 @@ export default function EditBookPage() {
             onChangeText={setBookAuthor}
             placeholder=""
           />
-          <Pressable onPress={handleDeleteBook} className="self-start">
-            <View className="flex-row items-center gap-x-2 bg-red-100 rounded-xl py-2 px-4">
-              <ThemedIcon name="TriangleAlert" size={24} color="red-500" />
-              <Text variant="body-semibold" className="text-red-500">
-                Delete Book
-              </Text>
-            </View>
-          </Pressable>
+          <DeleteButton onPress={handleDeleteBook} label="Delete Book" />
         </View>
         <Separator color="slate" className="my-4" />
 
@@ -154,13 +148,7 @@ export default function EditBookPage() {
         <View>
           <View className="flex-row justify-between items-center mb-4">
             <Text variant="title-xl">Sections</Text>
-            <Pressable
-              onPress={handleAddSection}
-              className="bg-slate-100 rounded-xl py-2 px-4 text-lg border border-slate-300 flex-row items-center gap-x-1.5"
-            >
-              <ThemedIcon name="Plus" size={16} color="slate-500" />
-              <Text variant="body-semibold">Add Section</Text>
-            </Pressable>
+            <AddItemButton onPress={handleAddSection} label="Add Section" />
           </View>
 
           <View className="gap-y-4 mb-4">

--- a/front-end/app/library-forms/edit-book/[bookId].tsx
+++ b/front-end/app/library-forms/edit-book/[bookId].tsx
@@ -1,8 +1,9 @@
 import { InputWithDelete } from '@/components/forms/InputWithDelete';
 import { TextInputWithLabel } from '@/components/forms/TextInputWithLabel';
-import { DeleteButton } from '@/components/shared/DeleteButton';
 import { AddItemButton } from '@/components/shared/AddItemButton';
+import { DeleteButton } from '@/components/shared/DeleteButton';
 import { Separator } from '@/components/shared/Separator';
+import { ActionButton } from '@/components/ui/action-button';
 import { Text } from '@/components/ui/text';
 import { deleteBook, updateBook } from '@/lib/supabase/book';
 import { deleteSections, insertSections, updateSection } from '@/lib/supabase/section';
@@ -10,8 +11,7 @@ import { useBooksStore } from '@/stores/book-store';
 import { useSectionsStore } from '@/stores/section-store';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useEffect, useState } from 'react';
-import { ActivityIndicator, Alert, Pressable, View } from 'react-native';
-import { ActionButton } from '@/components/ui/action-button';
+import { ActivityIndicator, Alert, View } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 
 export type EditableSection = {

--- a/front-end/app/library-forms/edit-section/[sectionId].tsx
+++ b/front-end/app/library-forms/edit-section/[sectionId].tsx
@@ -1,7 +1,8 @@
 import { InputWithDelete } from '@/components/forms/InputWithDelete';
 
 import { TextInputWithLabel } from '@/components/forms/TextInputWithLabel';
-import { ThemedIcon } from '@/components/icons/ThemedIcon';
+import { DeleteButton } from '@/components/shared/DeleteButton';
+import { AddItemButton } from '@/components/shared/AddItemButton';
 import { Separator } from '@/components/shared/Separator';
 import { Text } from '@/components/ui/text';
 import { deleteExercises, insertExercises, updateExercise } from '@/lib/supabase/exercise';
@@ -130,27 +131,14 @@ export default function EditSectionPage() {
             onChangeText={setSectionName}
             placeholder="Example Section"
           />
-          <Pressable onPress={handleDeleteSection} className="self-start">
-            <View className="flex-row items-center gap-x-2 bg-red-100 rounded-xl py-2 px-4">
-              <ThemedIcon name="TriangleAlert" size={24} color="red-500" />
-              <Text variant="body-semibold" className="text-red-500">
-                Delete Section
-              </Text>
-            </View>
-          </Pressable>
+          <DeleteButton onPress={handleDeleteSection} label="Delete Section" />
           <Separator color="slate" className="my-4" />
 
           {/* Exercises */}
           <View>
             <View className="flex-row justify-between items-center mb-4">
               <Text variant="title-2xl">Exercises</Text>
-              <Pressable
-                onPress={handleAddExercise}
-                className="bg-slate-100 rounded-xl py-2 px-4 text-lg border border-slate-300 flex-row items-center gap-x-1.5"
-              >
-                <ThemedIcon name="Plus" size={16} color="slate-500" />
-                <Text variant="body-semibold">Add Exercise</Text>
-              </Pressable>
+              <AddItemButton onPress={handleAddExercise} label="Add Exercise" />
             </View>
 
             <View className="gap-y-2">

--- a/front-end/app/library-forms/edit-section/[sectionId].tsx
+++ b/front-end/app/library-forms/edit-section/[sectionId].tsx
@@ -1,9 +1,9 @@
 import { InputWithDelete } from '@/components/forms/InputWithDelete';
-
 import { TextInputWithLabel } from '@/components/forms/TextInputWithLabel';
-import { DeleteButton } from '@/components/shared/DeleteButton';
 import { AddItemButton } from '@/components/shared/AddItemButton';
+import { DeleteButton } from '@/components/shared/DeleteButton';
 import { Separator } from '@/components/shared/Separator';
+import { ActionButton } from '@/components/ui/action-button';
 import { Text } from '@/components/ui/text';
 import { deleteExercises, insertExercises, updateExercise } from '@/lib/supabase/exercise';
 import { deleteSections, updateSection } from '@/lib/supabase/section';
@@ -11,8 +11,7 @@ import { useExercisesStore } from '@/stores/exercise-store';
 import { useSectionsStore } from '@/stores/section-store';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useEffect, useState } from 'react';
-import { ActivityIndicator, Alert, Pressable, View } from 'react-native';
-import { ActionButton } from '@/components/ui/action-button';
+import { ActivityIndicator, Alert, View } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 
 export type EditableExercise = {

--- a/front-end/app/library-forms/edit-song/[songId].tsx
+++ b/front-end/app/library-forms/edit-song/[songId].tsx
@@ -1,5 +1,5 @@
 import { TextInputWithLabel } from '@/components/forms/TextInputWithLabel';
-import { ThemedIcon } from '@/components/icons/ThemedIcon';
+import { DeleteButton } from '@/components/shared/DeleteButton';
 import { Text } from '@/components/ui/text';
 import { deleteSong, updateSong } from '@/lib/supabase/song';
 import { useArtistsStore } from '@/stores/artist-store';
@@ -126,14 +126,7 @@ export default function EditSongPage() {
               </View>
             )}
           </View>
-          <Pressable onPress={handleDeleteSong} className="self-start mb-10">
-            <View className="flex-row items-center gap-x-2 bg-red-100 rounded-xl py-2 px-4">
-              <ThemedIcon name="TriangleAlert" size={24} color="red-500" />
-              <Text variant="body-semibold" className="text-red-500">
-                Delete Song
-              </Text>
-            </View>
-          </Pressable>
+          <DeleteButton onPress={handleDeleteSong} label="Delete Song" />
 
           <Pressable
             onPress={handleSaveSong}

--- a/front-end/app/session-detail/active-session.tsx
+++ b/front-end/app/session-detail/active-session.tsx
@@ -1,4 +1,5 @@
 import { ThemedIcon } from '@/components/icons/ThemedIcon';
+import { AddItemButton } from '@/components/shared/AddItemButton';
 import { ActiveSessionItemCard } from '@/components/sessions/ActiveSessionItemCard';
 import { Text } from '@/components/ui/text';
 import { useDraftSessionsStore } from '@/stores/draft-sessions-store';
@@ -129,15 +130,13 @@ export default function ActiveSessionPage() {
 
       {/* End Session Button */}
       <View className="bg-white border-t border-slate-200 flex-row justify-between ">
-        <Pressable
+        <AddItemButton
           className="mx-4 my-4 flex-1 flex-row items-center justify-center bg-slate-100 rounded-xl py-4 active:opacity-80"
+          iconSize={20}
+          iconColor="black"
           onPress={() => router.push('/session-detail/add-item-to-session')}
-        >
-          <ThemedIcon name="Plus" size={20} color="black" />
-          <Text variant="body-semibold" className="text-slate-900 text-lg">
-            Add Item
-          </Text>
-        </Pressable>
+          label="Add Item"
+        />
         <Pressable
           className="mx-4 my-4 flex-1 flex-row items-center justify-center bg-red-500 rounded-xl py-4 active:opacity-80"
           onPress={handleEndSession}

--- a/front-end/components/icons/ThemedIcon.tsx
+++ b/front-end/components/icons/ThemedIcon.tsx
@@ -60,7 +60,7 @@ const FILLED_ICONS: IconName[] = ['Play', 'Pause'];
 
 type IconName = keyof typeof ICONS;
 
-interface ThemedIconProps {
+export interface ThemedIconProps {
   name: IconName;
   size?: number;
   color?: string; // e.g., "red-500", "slate-300", "#ef4444"

--- a/front-end/components/shared/AddItemButton.tsx
+++ b/front-end/components/shared/AddItemButton.tsx
@@ -1,5 +1,6 @@
 import { ThemedIcon, type ThemedIconProps } from '@/components/icons/ThemedIcon';
 import { Text, type TextProps } from '@/components/ui/text';
+import { cn } from '@/utils/tailwind-utils';
 import { Pressable } from 'react-native';
 
 interface AddItemButtonProps {
@@ -19,10 +20,16 @@ export function AddItemButton({
   iconSize = 16,
   textVariant = 'body-semibold',
   iconColor = 'slate-500',
-  className = 'bg-slate-100 rounded-xl py-2 px-4 border border-slate-300 flex-row items-center gap-x-1.5',
+  className,
 }: AddItemButtonProps) {
   return (
-    <Pressable onPress={onPress} className={className}>
+    <Pressable
+      onPress={onPress}
+      className={cn(
+        'bg-slate-100 rounded-xl py-2 px-4 border border-slate-300 flex-row justify-center items-center gap-x-1.5',
+        className
+      )}
+    >
       <ThemedIcon name={iconName} size={iconSize} color={iconColor} />
       <Text variant={textVariant}>{label}</Text>
     </Pressable>

--- a/front-end/components/shared/AddItemButton.tsx
+++ b/front-end/components/shared/AddItemButton.tsx
@@ -1,0 +1,30 @@
+import { ThemedIcon } from '@/components/icons/ThemedIcon';
+import { Text } from '@/components/ui/text';
+import { Pressable } from 'react-native';
+
+interface AddItemButtonProps {
+  label: string;
+  onPress?: () => void;
+  iconName?: Parameters<typeof ThemedIcon>[0]['name'];
+  iconSize?: number;
+  textVariant?: Parameters<typeof Text>[0]['variant'];
+  iconColor?: string;
+  className?: string;
+}
+
+export function AddItemButton({
+  label,
+  onPress,
+  iconName = 'Plus',
+  iconSize = 16,
+  textVariant = 'body-semibold',
+  iconColor = 'slate-500',
+  className = 'bg-slate-100 rounded-xl py-2 px-4 border border-slate-300 flex-row items-center gap-x-1.5',
+}: AddItemButtonProps) {
+  return (
+    <Pressable onPress={onPress} className={className}>
+      <ThemedIcon name={iconName} size={iconSize} color={iconColor} />
+      <Text variant={textVariant}>{label}</Text>
+    </Pressable>
+  );
+}

--- a/front-end/components/shared/AddItemButton.tsx
+++ b/front-end/components/shared/AddItemButton.tsx
@@ -1,13 +1,13 @@
-import { ThemedIcon } from '@/components/icons/ThemedIcon';
-import { Text } from '@/components/ui/text';
+import { ThemedIcon, type ThemedIconProps } from '@/components/icons/ThemedIcon';
+import { Text, type TextProps } from '@/components/ui/text';
 import { Pressable } from 'react-native';
 
 interface AddItemButtonProps {
   label: string;
   onPress?: () => void;
-  iconName?: Parameters<typeof ThemedIcon>[0]['name'];
+  iconName?: ThemedIconProps['name'];
   iconSize?: number;
-  textVariant?: Parameters<typeof Text>[0]['variant'];
+  textVariant?: TextProps['variant'];
   iconColor?: string;
   className?: string;
 }

--- a/front-end/components/shared/DeleteButton.tsx
+++ b/front-end/components/shared/DeleteButton.tsx
@@ -1,13 +1,13 @@
-import { ThemedIcon } from '@/components/icons/ThemedIcon';
-import { Text } from '@/components/ui/text';
+import { ThemedIcon, type ThemedIconProps } from '@/components/icons/ThemedIcon';
+import { Text, type TextProps } from '@/components/ui/text';
 import { Pressable, View } from 'react-native';
 
 interface DeleteButtonProps {
   label: string;
   onPress?: () => void;
-  iconName?: Parameters<typeof ThemedIcon>[0]['name'];
+  iconName?: ThemedIconProps['name'];
   iconSize?: number;
-  textVariant?: Parameters<typeof Text>[0]['variant'];
+  textVariant?: TextProps['variant'];
 }
 
 export function DeleteButton({

--- a/front-end/components/shared/DeleteButton.tsx
+++ b/front-end/components/shared/DeleteButton.tsx
@@ -1,0 +1,30 @@
+import { ThemedIcon } from '@/components/icons/ThemedIcon';
+import { Text } from '@/components/ui/text';
+import { Pressable, View } from 'react-native';
+
+interface DeleteButtonProps {
+  label: string;
+  onPress?: () => void;
+  iconName?: Parameters<typeof ThemedIcon>[0]['name'];
+  iconSize?: number;
+  textVariant?: Parameters<typeof Text>[0]['variant'];
+}
+
+export function DeleteButton({
+  label,
+  onPress,
+  iconName = 'TriangleAlert',
+  iconSize = 24,
+  textVariant = 'body-semibold',
+}: DeleteButtonProps) {
+  return (
+    <Pressable onPress={onPress} className="self-start">
+      <View className="flex-row items-center gap-x-2 bg-red-100 rounded-xl py-2 px-4">
+        <ThemedIcon name={iconName} size={iconSize} color="red-500" />
+        <Text variant={textVariant} className="text-red-500">
+          {label}
+        </Text>
+      </View>
+    </Pressable>
+  );
+}

--- a/front-end/components/ui/text.tsx
+++ b/front-end/components/ui/text.tsx
@@ -6,7 +6,7 @@ import { Text as RNText } from 'react-native';
 
 const TextClassContext = React.createContext<string | undefined>(undefined);
 
-interface TextProps extends SlottableTextProps {
+export interface TextProps extends SlottableTextProps {
   variant?:
     | 'body'
     | 'body-semibold'


### PR DESCRIPTION
## Summary
- create reusable `DeleteButton` and `AddItemButton` components
- use these new components in edit views and session pages

## Testing
- `npm run --prefix front-end lint`
- `npm run --prefix front-end typecheck`
- `npm run --prefix front-end test`
- `npm run --prefix front-end format:check`


------
https://chatgpt.com/codex/tasks/task_e_6859f46273e8832bbfef509e10c8d5a3